### PR TITLE
Add `.editorconfig` & apply style rules

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,368 @@
+root = true
+
+# All files
+[*]
+indent_style             = space
+trim_trailing_whitespace = true
+
+# New line preferences
+end_of_line          = crlf
+insert_final_newline = true
+
+# Xml project files
+[*.{csproj,proj}]
+indent_size = 2
+
+# Xml config files
+[*.{props,targets}]
+indent_size = 2
+
+# Other markup files
+[*.{json,xml,yml}]
+indent_size = 2
+
+# Markdown files
+[*.md]
+indent_size              = 2
+trim_trailing_whitespace = false
+
+# C# files
+[*.cs]
+indent_size = 4
+
+
+#### C# Style Rules ####
+[*.cs]
+
+file_header_template = unset
+
+# Uncategorized rules (diagnostics without a property equivalent)
+
+dotnet_diagnostic.IDE0001.severity = suggestion # Simplify name
+dotnet_diagnostic.IDE0002.severity = suggestion # Simplify member access
+dotnet_diagnostic.IDE0004.severity = warning    # Remove unnecessary cast
+dotnet_diagnostic.IDE0005.severity = warning    # Remove unnecessary import
+dotnet_diagnostic.IDE0035.severity = suggestion # Remove unreachable code
+dotnet_diagnostic.IDE0050.severity = warning    # Convert anonymous type to tuple
+dotnet_diagnostic.IDE0051.severity = suggestion # Remove unused private member
+dotnet_diagnostic.IDE0052.severity = suggestion # Remove unread private member
+dotnet_diagnostic.IDE0064.severity = suggestion # Make struct fields writable
+dotnet_diagnostic.IDE0080.severity = warning    # Remove unnecessary suppression operator
+dotnet_diagnostic.IDE0082.severity = warning    # Convert `typeof` to `nameof`
+dotnet_diagnostic.IDE0100.severity = warning    # Remove unnecessary equality operator
+dotnet_diagnostic.IDE0110.severity = suggestion # Remove unnecessary discard
+dotnet_diagnostic.IDE0120.severity = warning    # Simplify LINQ expression
+dotnet_diagnostic.IDE0280.severity = warning    # Use `nameof`
+
+
+#### .NET Coding Conventions ####
+
+# Organize usings
+dotnet_separate_import_directive_groups = true
+dotnet_sort_system_directives_first     = true
+
+# this. and Me. preferences
+dotnet_style_qualification_for_event    = false:warning
+dotnet_style_qualification_for_field    = false:warning
+dotnet_style_qualification_for_method   = false:warning
+dotnet_style_qualification_for_property = false:warning
+
+# Language keywords vs BCL types preferences
+dotnet_style_predefined_type_for_locals_parameters_members = true:warning
+dotnet_style_predefined_type_for_member_access             = true:warning
+
+# Parentheses preferences
+dotnet_style_parentheses_in_arithmetic_binary_operators = always_for_clarity:warning
+dotnet_style_parentheses_in_other_binary_operators      = always_for_clarity:warning
+dotnet_style_parentheses_in_other_operators             = never_if_unnecessary:warning
+dotnet_style_parentheses_in_relational_binary_operators = always_for_clarity:warning
+
+# Modifier preferences
+dotnet_style_require_accessibility_modifiers = for_non_interface_members:warning
+
+# Expression-level preferences
+dotnet_style_coalesce_expression                                 = true:suggestion
+dotnet_style_collection_initializer                              = true:warning
+dotnet_style_explicit_tuple_names                                = true:warning
+dotnet_style_null_propagation                                    = true:suggestion
+dotnet_style_object_initializer                                  = true:warning
+dotnet_style_operator_placement_when_wrapping                    = beginning_of_line
+dotnet_style_prefer_auto_properties                              = true:warning
+dotnet_style_prefer_collection_expression                        = true:suggestion
+dotnet_style_prefer_compound_assignment                          = true:warning
+dotnet_style_prefer_conditional_expression_over_assignment       = true:silent
+dotnet_style_prefer_conditional_expression_over_return           = false:silent
+dotnet_style_prefer_foreach_explicit_cast_in_source              = when_strongly_typed
+dotnet_style_prefer_inferred_anonymous_type_member_names         = false:suggestion
+dotnet_style_prefer_inferred_tuple_names                         = false:suggestion
+dotnet_style_prefer_is_null_check_over_reference_equality_method = true:warning
+dotnet_style_prefer_simplified_boolean_expressions               = true:suggestion
+dotnet_style_prefer_simplified_interpolation                     = true:suggestion
+csharp_style_throw_expression                                    = false:warning
+
+# Field preferences
+dotnet_style_readonly_field = true:warning
+
+# Parameter preferences
+dotnet_code_quality_unused_parameters = all:suggestion
+
+# Suppression preferences
+dotnet_remove_unnecessary_suppression_exclusions = suggestion
+
+# New line preferences
+dotnet_style_allow_multiple_blank_lines_experimental              = false:warning
+dotnet_style_allow_statement_immediately_after_block_experimental = false:warning
+
+
+#### C# Coding Conventions ####
+
+# readonly preferences
+csharp_style_prefer_readonly_struct        = true:warning
+csharp_style_prefer_readonly_struct_member = true:warning
+
+# var preferences
+csharp_style_var_elsewhere             = false:suggestion
+csharp_style_var_for_built_in_types    = false:suggestion
+csharp_style_var_when_type_is_apparent = true:suggestion
+
+# Expression-bodied members
+csharp_style_expression_bodied_accessors       = when_on_single_line:suggestion
+csharp_style_expression_bodied_constructors    = false:warning
+csharp_style_expression_bodied_indexers        = when_on_single_line:suggestion
+csharp_style_expression_bodied_lambdas         = when_on_single_line:suggestion
+csharp_style_expression_bodied_local_functions = false:warning
+csharp_style_expression_bodied_methods         = false:warning
+csharp_style_expression_bodied_operators       = false:warning
+csharp_style_expression_bodied_properties      = when_on_single_line:suggestion
+
+# Pattern matching preferences
+csharp_style_pattern_matching_over_as_with_null_check = true:warning
+csharp_style_pattern_matching_over_is_with_cast_check = true:warning
+csharp_style_prefer_not_pattern                       = true:warning
+csharp_style_prefer_extended_property_pattern         = true:warning
+csharp_style_prefer_pattern_matching                  = true:suggestion
+csharp_style_prefer_switch_expression                 = true:suggestion
+
+# Null-checking preferences
+csharp_style_conditional_delegate_call = true:suggestion
+
+# Modifier preferences
+csharp_prefer_static_local_function = true:warning
+csharp_preferred_modifier_order     = public,private,protected,internal,static,extern,new,virtual,abstract,sealed,override,readonly,unsafe,volatile,async:silent
+
+# Code-block preferences
+csharp_prefer_braces                        = true:warning
+csharp_prefer_simple_using_statement        = true:warning
+csharp_style_prefer_method_group_conversion = true:suggestion
+csharp_style_prefer_top_level_statements    = true:suggestion
+
+# Expression-level preferences
+csharp_prefer_simple_default_expression                     = true:warning
+csharp_style_deconstructed_variable_declaration             = true:warning
+csharp_style_implicit_object_creation_when_type_is_apparent = true:warning
+csharp_style_inlined_variable_declaration                   = true:warning
+csharp_style_pattern_local_over_anonymous_function          = true:warning
+csharp_style_prefer_index_operator                          = true:warning
+csharp_style_prefer_local_over_anonymous_function           = true:warning
+csharp_style_prefer_null_check_over_type_check              = true:warning
+csharp_style_prefer_range_operator                          = true:warning
+csharp_style_prefer_tuple_swap                              = true:warning
+csharp_style_prefer_utf8_string_literals                    = true:suggestion
+csharp_style_unused_value_assignment_preference             = discard_variable:none
+csharp_style_unused_value_expression_statement_preference   = discard_variable:none
+
+# 'using' directive preferences
+csharp_using_directive_placement = outside_namespace:warning
+
+
+#### C# Formatting Rules ####
+
+# New line preferences
+csharp_new_line_before_catch                                                      = true
+csharp_new_line_before_else                                                       = true
+csharp_new_line_before_finally                                                    = true
+csharp_new_line_before_members_in_anonymous_types                                 = true
+csharp_new_line_before_members_in_object_initializers                             = true
+csharp_new_line_before_open_brace                                                 = all
+csharp_new_line_between_query_expression_clauses                                  = true
+csharp_style_allow_blank_line_after_colon_in_constructor_initializer_experimental = false:warning
+csharp_style_allow_blank_line_after_token_in_conditional_expression_experimental  = false:warning
+csharp_style_allow_blank_line_after_token_in_arrow_expression_clause_experimental = false:warning
+csharp_style_allow_blank_lines_between_consecutive_braces_experimental            = false:warning
+csharp_style_allow_embedded_statements_on_same_line_experimental                  = false:warning
+
+# Indentation preferences
+csharp_indent_block_contents           = true
+csharp_indent_braces                   = false
+csharp_indent_case_contents            = true
+csharp_indent_case_contents_when_block = false
+csharp_indent_labels                   = one_less_than_current
+csharp_indent_switch_labels            = true
+
+# Space preferences
+csharp_space_after_cast                                                  = false
+csharp_space_after_colon_in_inheritance_clause                           = true
+csharp_space_after_comma                                                 = true
+csharp_space_after_dot                                                   = false
+csharp_space_after_keywords_in_control_flow_statements                   = true
+csharp_space_after_semicolon_in_for_statement                            = true
+csharp_space_around_binary_operators                                     = before_and_after
+csharp_space_around_declaration_statements                               = false
+csharp_space_before_colon_in_inheritance_clause                          = true
+csharp_space_before_comma                                                = false
+csharp_space_before_dot                                                  = false
+csharp_space_before_open_square_brackets                                 = false
+csharp_space_before_semicolon_in_for_statement                           = false
+csharp_space_between_empty_square_brackets                               = false
+csharp_space_between_method_call_empty_parameter_list_parentheses        = false
+csharp_space_between_method_call_name_and_opening_parenthesis            = false
+csharp_space_between_method_call_parameter_list_parentheses              = false
+csharp_space_between_method_declaration_empty_parameter_list_parentheses = false
+csharp_space_between_method_declaration_name_and_open_parenthesis        = false
+csharp_space_between_method_declaration_parameter_list_parentheses       = false
+csharp_space_between_parentheses                                         = false
+csharp_space_between_square_brackets                                     = false
+
+# Wrapping preferences
+csharp_preserve_single_line_blocks     = true
+csharp_preserve_single_line_statements = true
+
+# Namespace preferences
+csharp_style_namespace_declarations = file_scoped:warning
+dotnet_style_namespace_match_folder = false
+
+# Constructor preferences
+csharp_style_prefer_primary_constructors = false:none
+
+
+#### Naming styles ####
+
+# Naming rules
+
+dotnet_naming_rule.types_and_namespaces_should_be_pascalcase.severity = suggestion
+dotnet_naming_rule.types_and_namespaces_should_be_pascalcase.symbols  = types_and_namespaces
+dotnet_naming_rule.types_and_namespaces_should_be_pascalcase.style    = pascalcase
+
+dotnet_naming_rule.interfaces_should_be_ipascalcase.severity = suggestion
+dotnet_naming_rule.interfaces_should_be_ipascalcase.symbols  = interfaces
+dotnet_naming_rule.interfaces_should_be_ipascalcase.style    = ipascalcase
+
+dotnet_naming_rule.non_field_members_should_be_pascalcase.severity = suggestion
+dotnet_naming_rule.non_field_members_should_be_pascalcase.symbols  = non_field_members
+dotnet_naming_rule.non_field_members_should_be_pascalcase.style    = pascalcase
+
+dotnet_naming_rule.constant_fields_should_be_pascalcase.severity = suggestion
+dotnet_naming_rule.constant_fields_should_be_pascalcase.symbols  = constant_fields
+dotnet_naming_rule.constant_fields_should_be_pascalcase.style    = pascalcase
+
+dotnet_naming_rule.public_static_fields_should_be_pascalcase.severity = suggestion
+dotnet_naming_rule.public_static_fields_should_be_pascalcase.symbols  = public_static_fields
+dotnet_naming_rule.public_static_fields_should_be_pascalcase.style    = pascalcase
+
+dotnet_naming_rule.public_fields_should_be_pascalcase.severity = suggestion
+dotnet_naming_rule.public_fields_should_be_pascalcase.symbols  = public_fields
+dotnet_naming_rule.public_fields_should_be_pascalcase.style    = pascalcase
+
+dotnet_naming_rule.private_fields_should_be__camelcase.severity = suggestion
+dotnet_naming_rule.private_fields_should_be__camelcase.symbols  = private_fields
+dotnet_naming_rule.private_fields_should_be__camelcase.style    = _camelcase
+
+dotnet_naming_rule.type_parameters_should_be_tpascalcase.severity = warning
+dotnet_naming_rule.type_parameters_should_be_tpascalcase.symbols  = type_parameters
+dotnet_naming_rule.type_parameters_should_be_tpascalcase.style    = tpascalcase
+
+dotnet_naming_rule.parameters_should_be_camelcase.severity = suggestion
+dotnet_naming_rule.parameters_should_be_camelcase.symbols  = parameters
+dotnet_naming_rule.parameters_should_be_camelcase.style    = camelcase
+
+dotnet_naming_rule.local_constants_should_be_pascalcase.severity = warning
+dotnet_naming_rule.local_constants_should_be_pascalcase.symbols  = local_constants
+dotnet_naming_rule.local_constants_should_be_pascalcase.style    = pascalcase
+
+dotnet_naming_rule.local_variables_should_be_camelcase.severity = warning
+dotnet_naming_rule.local_variables_should_be_camelcase.symbols  = local_variables
+dotnet_naming_rule.local_variables_should_be_camelcase.style    = camelcase
+
+dotnet_naming_rule.local_functions_should_be_camelcase.severity = warning
+dotnet_naming_rule.local_functions_should_be_camelcase.symbols  = local_functions
+dotnet_naming_rule.local_functions_should_be_camelcase.style    = camelcase
+
+# Symbol specifications
+
+dotnet_naming_symbols.types_and_namespaces.applicable_kinds           = namespace, class, struct, interface, enum
+dotnet_naming_symbols.types_and_namespaces.applicable_accessibilities = public, internal, private, protected, protected_internal, private_protected
+dotnet_naming_symbols.types_and_namespaces.required_modifiers         =
+
+dotnet_naming_symbols.interfaces.applicable_kinds           = interface
+dotnet_naming_symbols.interfaces.applicable_accessibilities = public, internal, private, protected, protected_internal, private_protected
+dotnet_naming_symbols.interfaces.required_modifiers         =
+
+dotnet_naming_symbols.non_field_members.applicable_kinds           = property, event, delegate, method
+dotnet_naming_symbols.non_field_members.applicable_accessibilities = public, internal, private, protected, protected_internal, private_protected
+dotnet_naming_symbols.non_field_members.required_modifiers         =
+
+dotnet_naming_symbols.constant_fields.applicable_kinds           = field
+dotnet_naming_symbols.constant_fields.applicable_accessibilities = public, internal, private, protected, protected_internal, private_protected
+dotnet_naming_symbols.constant_fields.required_modifiers         = const
+
+dotnet_naming_symbols.public_static_fields.applicable_kinds           = field
+dotnet_naming_symbols.public_static_fields.applicable_accessibilities = public, internal
+dotnet_naming_symbols.public_static_fields.required_modifiers         = static
+
+dotnet_naming_symbols.public_fields.applicable_kinds           = field
+dotnet_naming_symbols.public_fields.applicable_accessibilities = public, internal
+dotnet_naming_symbols.public_fields.required_modifiers         =
+
+dotnet_naming_symbols.private_fields.applicable_kinds           = field
+dotnet_naming_symbols.private_fields.applicable_accessibilities = private, protected, protected_internal, private_protected
+dotnet_naming_symbols.private_fields.required_modifiers         =
+
+dotnet_naming_symbols.type_parameters.applicable_kinds           = type_parameter
+dotnet_naming_symbols.type_parameters.applicable_accessibilities = *
+dotnet_naming_symbols.type_parameters.required_modifiers         =
+
+dotnet_naming_symbols.parameters.applicable_kinds           = parameter
+dotnet_naming_symbols.parameters.applicable_accessibilities = *
+dotnet_naming_symbols.parameters.required_modifiers         =
+
+dotnet_naming_symbols.local_constants.applicable_kinds           = local
+dotnet_naming_symbols.local_constants.applicable_accessibilities = local
+dotnet_naming_symbols.local_constants.required_modifiers         = const
+
+dotnet_naming_symbols.local_variables.applicable_kinds           = local
+dotnet_naming_symbols.local_variables.applicable_accessibilities = local
+dotnet_naming_symbols.local_variables.required_modifiers         =
+
+dotnet_naming_symbols.local_functions.applicable_kinds           = local_function
+dotnet_naming_symbols.local_functions.applicable_accessibilities = local
+dotnet_naming_symbols.local_functions.required_modifiers         =
+
+# Naming styles
+
+dotnet_naming_style.pascalcase.required_prefix =
+dotnet_naming_style.pascalcase.required_suffix =
+dotnet_naming_style.pascalcase.word_separator  =
+dotnet_naming_style.pascalcase.capitalization  = pascal_case
+
+dotnet_naming_style.ipascalcase.required_prefix = I
+dotnet_naming_style.ipascalcase.required_suffix =
+dotnet_naming_style.ipascalcase.word_separator  =
+dotnet_naming_style.ipascalcase.capitalization  = pascal_case
+
+dotnet_naming_style.tpascalcase.required_prefix = T
+dotnet_naming_style.tpascalcase.required_suffix =
+dotnet_naming_style.tpascalcase.word_separator  =
+dotnet_naming_style.tpascalcase.capitalization  = pascal_case
+
+dotnet_naming_style.camelcase.required_prefix =
+dotnet_naming_style.camelcase.required_suffix =
+dotnet_naming_style.camelcase.word_separator  =
+dotnet_naming_style.camelcase.capitalization  = camel_case
+
+dotnet_naming_style._camelcase.required_prefix = _
+dotnet_naming_style._camelcase.required_suffix =
+dotnet_naming_style._camelcase.word_separator  =
+dotnet_naming_style._camelcase.capitalization  = camel_case
+
+
+#### Suppressions ####

--- a/props/LiveSplit.TotalPlaytime.props
+++ b/props/LiveSplit.TotalPlaytime.props
@@ -4,6 +4,7 @@
   <PropertyGroup>
     <LangVersion>12</LangVersion>
 
+    <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
     <Nullable>disable</Nullable>
   </PropertyGroup>
 

--- a/props/LiveSplit.TotalPlaytime.props
+++ b/props/LiveSplit.TotalPlaytime.props
@@ -2,6 +2,8 @@
 
   <!-- Project properties. -->
   <PropertyGroup>
+    <LangVersion>12</LangVersion>
+
     <Nullable>disable</Nullable>
   </PropertyGroup>
 

--- a/src/LiveSplit.TotalPlaytime/LiveSplit.TotalPlaytime.csproj
+++ b/src/LiveSplit.TotalPlaytime/LiveSplit.TotalPlaytime.csproj
@@ -13,4 +13,8 @@
     <ProjectReference Include="$(LsSrcPath)\UpdateManager\UpdateManager.csproj" Private="false" ExcludeAssets="runtime" />
   </ItemGroup>
 
+  <ItemGroup>
+    <PackageReference Include="PolySharp" Version="1.14.1" PrivateAssets="all" />
+  </ItemGroup>
+
 </Project>

--- a/src/LiveSplit.TotalPlaytime/TimeFormatters/DaysTimeFormatter.cs
+++ b/src/LiveSplit.TotalPlaytime/TimeFormatters/DaysTimeFormatter.cs
@@ -13,15 +13,22 @@ public class DaysTimeFormatter : ITimeFormatter
             var builder = new StringBuilder();
 
             if (time.Value.TotalDays >= 1)
+            {
                 builder.Append((int)time.Value.TotalDays).Append("d ");
+            }
 
             if (time.Value.TotalHours >= 1)
+            {
                 builder.Append(time.Value.ToString(@"h\:mm\:ss", CultureInfo.InvariantCulture));
+            }
             else
+            {
                 builder.Append(time.Value.ToString(@"m\:ss", CultureInfo.InvariantCulture));
+            }
 
             return builder.ToString();
         }
+
         return "0";
     }
 }

--- a/src/LiveSplit.TotalPlaytime/TimeFormatters/DaysTimeFormatter.cs
+++ b/src/LiveSplit.TotalPlaytime/TimeFormatters/DaysTimeFormatter.cs
@@ -2,27 +2,26 @@
 using System.Globalization;
 using System.Text;
 
-namespace LiveSplit.TimeFormatters
+namespace LiveSplit.TimeFormatters;
+
+public class DaysTimeFormatter : ITimeFormatter
 {
-    public class DaysTimeFormatter : ITimeFormatter
+    public string Format(TimeSpan? time)
     {
-        public string Format(TimeSpan? time)
+        if (time.HasValue)
         {
-            if (time.HasValue)
-            {
-                var builder = new StringBuilder();
+            var builder = new StringBuilder();
 
-                if (time.Value.TotalDays >= 1)
-                    builder.Append((int)time.Value.TotalDays).Append("d ");
+            if (time.Value.TotalDays >= 1)
+                builder.Append((int)time.Value.TotalDays).Append("d ");
 
-                if (time.Value.TotalHours >= 1)
-                    builder.Append(time.Value.ToString(@"h\:mm\:ss", CultureInfo.InvariantCulture));
-                else
-                    builder.Append(time.Value.ToString(@"m\:ss", CultureInfo.InvariantCulture));
+            if (time.Value.TotalHours >= 1)
+                builder.Append(time.Value.ToString(@"h\:mm\:ss", CultureInfo.InvariantCulture));
+            else
+                builder.Append(time.Value.ToString(@"m\:ss", CultureInfo.InvariantCulture));
 
-                return builder.ToString();
-            }
-            return "0";
+            return builder.ToString();
         }
+        return "0";
     }
 }

--- a/src/LiveSplit.TotalPlaytime/UI/Components/TotalPlaytimeComponent.cs
+++ b/src/LiveSplit.TotalPlaytime/UI/Components/TotalPlaytimeComponent.cs
@@ -119,11 +119,11 @@ public class TotalPlaytimeComponent : IComponent
 
     public TimeSpan CalculateTotalPlaytime(LiveSplitState state)
     {
-        var totalPlaytime = TimeSpan.Zero;
+        TimeSpan totalPlaytime = TimeSpan.Zero;
 
-        foreach (var attempt in state.Run.AttemptHistory)
+        foreach (Attempt attempt in state.Run.AttemptHistory)
         {
-            var duration = attempt.Duration;
+            TimeSpan? duration = attempt.Duration;
 
             if (duration.HasValue)
             {
@@ -135,7 +135,7 @@ public class TotalPlaytimeComponent : IComponent
                 //Must be < 1.6.0 and a reset
                 //Calculate the sum of the segments for that run
 
-                foreach (var segment in state.Run)
+                foreach (ISegment segment in state.Run)
                 {
                     if (segment.SegmentHistory.TryGetValue(attempt.Index, out Time segmentHistoryElement) && segmentHistoryElement.RealTime.HasValue)
                     {

--- a/src/LiveSplit.TotalPlaytime/UI/Components/TotalPlaytimeComponent.cs
+++ b/src/LiveSplit.TotalPlaytime/UI/Components/TotalPlaytimeComponent.cs
@@ -137,8 +137,7 @@ public class TotalPlaytimeComponent : IComponent
 
                 foreach (var segment in state.Run)
                 {
-                    Time segmentHistoryElement;
-                    if (segment.SegmentHistory.TryGetValue(attempt.Index, out segmentHistoryElement) && segmentHistoryElement.RealTime.HasValue)
+                    if (segment.SegmentHistory.TryGetValue(attempt.Index, out Time segmentHistoryElement) && segmentHistoryElement.RealTime.HasValue)
                     {
                         totalPlaytime += segmentHistoryElement.RealTime.Value;
                     }

--- a/src/LiveSplit.TotalPlaytime/UI/Components/TotalPlaytimeComponent.cs
+++ b/src/LiveSplit.TotalPlaytime/UI/Components/TotalPlaytimeComponent.cs
@@ -55,8 +55,8 @@ public class TotalPlaytimeComponent : IComponent
     private void DrawBackground(Graphics g, LiveSplitState state, float width, float height)
     {
         if (Settings.BackgroundColor.A > 0
-            || Settings.BackgroundGradient != GradientType.Plain
-            && Settings.BackgroundColor2.A > 0)
+            || (Settings.BackgroundGradient != GradientType.Plain
+            && Settings.BackgroundColor2.A > 0))
         {
             var gradientBrush = new LinearGradientBrush(
                         new PointF(0, 0),
@@ -139,7 +139,9 @@ public class TotalPlaytimeComponent : IComponent
                 {
                     Time segmentHistoryElement;
                     if (segment.SegmentHistory.TryGetValue(attempt.Index, out segmentHistoryElement) && segmentHistoryElement.RealTime.HasValue)
+                    {
                         totalPlaytime += segmentHistoryElement.RealTime.Value;
+                    }
                 }
             }
         }

--- a/src/LiveSplit.TotalPlaytime/UI/Components/TotalPlaytimeComponent.cs
+++ b/src/LiveSplit.TotalPlaytime/UI/Components/TotalPlaytimeComponent.cs
@@ -174,5 +174,8 @@ public class TotalPlaytimeComponent : IComponent
         InternalComponent.Dispose();
     }
 
-    public int GetSettingsHashCode() => Settings.GetSettingsHashCode();
+    public int GetSettingsHashCode()
+    {
+        return Settings.GetSettingsHashCode();
+    }
 }

--- a/src/LiveSplit.TotalPlaytime/UI/Components/TotalPlaytimeComponent.cs
+++ b/src/LiveSplit.TotalPlaytime/UI/Components/TotalPlaytimeComponent.cs
@@ -1,178 +1,178 @@
-﻿using LiveSplit.Model;
-using LiveSplit.TimeFormatters;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Drawing;
 using System.Drawing.Drawing2D;
 using System.Windows.Forms;
 using System.Xml;
 
-namespace LiveSplit.UI.Components
+using LiveSplit.Model;
+using LiveSplit.TimeFormatters;
+
+namespace LiveSplit.UI.Components;
+
+public class TotalPlaytimeComponent : IComponent
 {
-    public class TotalPlaytimeComponent : IComponent
+    protected ITimeFormatter HoursTimeFormatter { get; set; }
+    protected ITimeFormatter DaysTimeFormatter { get; set; }
+    protected InfoTimeComponent InternalComponent { get; set; }
+    protected TotalPlaytimeSettings Settings { get; set; }
+
+    protected TimerPhase LastPhase { get; set; }
+    protected int LastAttemptCount { get; set; }
+    protected IRun LastRun { get; set; }
+
+    public string ComponentName => "Total Playtime";
+
+    public IDictionary<string, Action> ContextMenuControls => null;
+
+    public float HorizontalWidth => InternalComponent.HorizontalWidth;
+
+    public float VerticalHeight => InternalComponent.VerticalHeight;
+
+    public float MinimumHeight => InternalComponent.MinimumHeight;
+
+    public float MinimumWidth => InternalComponent.MinimumWidth;
+
+    public float PaddingBottom => InternalComponent.PaddingBottom;
+
+    public float PaddingLeft => InternalComponent.PaddingLeft;
+
+    public float PaddingRight => InternalComponent.PaddingRight;
+
+    public float PaddingTop => InternalComponent.PaddingTop;
+
+    public TotalPlaytimeComponent(LiveSplitState state)
     {
-        protected ITimeFormatter HoursTimeFormatter { get; set; }
-        protected ITimeFormatter DaysTimeFormatter { get; set; }
-        protected InfoTimeComponent InternalComponent { get; set; }
-        protected TotalPlaytimeSettings Settings { get; set; }
-
-        protected TimerPhase LastPhase { get; set; }
-        protected int LastAttemptCount { get; set; }
-        protected IRun LastRun { get; set; }
-
-        public string ComponentName => "Total Playtime";
-
-        public IDictionary<string, Action> ContextMenuControls => null;
-
-        public float HorizontalWidth => InternalComponent.HorizontalWidth;
-
-        public float VerticalHeight => InternalComponent.VerticalHeight;
-
-        public float MinimumHeight => InternalComponent.MinimumHeight;
-
-        public float MinimumWidth => InternalComponent.MinimumWidth;
-
-        public float PaddingBottom => InternalComponent.PaddingBottom;
-
-        public float PaddingLeft => InternalComponent.PaddingLeft;
-
-        public float PaddingRight => InternalComponent.PaddingRight;
-
-        public float PaddingTop => InternalComponent.PaddingTop;
-
-        public TotalPlaytimeComponent(LiveSplitState state)
+        HoursTimeFormatter = new RegularTimeFormatter();
+        DaysTimeFormatter = new DaysTimeFormatter();
+        InternalComponent = new InfoTimeComponent("Total Playtime", TimeSpan.Zero, DaysTimeFormatter);
+        Settings = new TotalPlaytimeSettings()
         {
-            HoursTimeFormatter = new RegularTimeFormatter();
-            DaysTimeFormatter = new DaysTimeFormatter();
-            InternalComponent = new InfoTimeComponent("Total Playtime", TimeSpan.Zero, DaysTimeFormatter);
-            Settings = new TotalPlaytimeSettings()
-            {
-                CurrentState = state
-            };
-        }
-
-        private void DrawBackground(Graphics g, LiveSplitState state, float width, float height)
-        {
-            if (Settings.BackgroundColor.A > 0
-                || Settings.BackgroundGradient != GradientType.Plain
-                && Settings.BackgroundColor2.A > 0)
-            {
-                var gradientBrush = new LinearGradientBrush(
-                            new PointF(0, 0),
-                            Settings.BackgroundGradient == GradientType.Horizontal
-                            ? new PointF(width, 0)
-                            : new PointF(0, height),
-                            Settings.BackgroundColor,
-                            Settings.BackgroundGradient == GradientType.Plain
-                            ? Settings.BackgroundColor
-                            : Settings.BackgroundColor2);
-                g.FillRectangle(gradientBrush, 0, 0, width, height);
-            }
-        }
-
-        public void DrawHorizontal(Graphics g, LiveSplitState state, float height, Region clipRegion)
-        {
-            DrawBackground(g, state, HorizontalWidth, height);
-
-            InternalComponent.NameLabel.HasShadow
-                = InternalComponent.ValueLabel.HasShadow
-                = state.LayoutSettings.DropShadows;
-
-            InternalComponent.NameLabel.ForeColor = Settings.OverrideTextColor ? Settings.TextColor : state.LayoutSettings.TextColor;
-            InternalComponent.ValueLabel.ForeColor = Settings.OverrideTimeColor ? Settings.TimeColor : state.LayoutSettings.TextColor;
-
-            InternalComponent.DrawHorizontal(g, state, height, clipRegion);
-        }
-
-        public void DrawVertical(Graphics g, LiveSplitState state, float width, Region clipRegion)
-        {
-            DrawBackground(g, state, width, VerticalHeight);
-
-            InternalComponent.DisplayTwoRows = Settings.Display2Rows;
-
-            InternalComponent.NameLabel.HasShadow
-                = InternalComponent.ValueLabel.HasShadow
-                = state.LayoutSettings.DropShadows;
-
-            InternalComponent.NameLabel.ForeColor = Settings.OverrideTextColor ? Settings.TextColor : state.LayoutSettings.TextColor;
-            InternalComponent.ValueLabel.ForeColor = Settings.OverrideTimeColor ? Settings.TimeColor : state.LayoutSettings.TextColor;
-
-            InternalComponent.DrawVertical(g, state, width, clipRegion);
-        }
-
-        public XmlNode GetSettings(XmlDocument document)
-        {
-            return Settings.GetSettings(document);
-        }
-
-        public Control GetSettingsControl(LayoutMode mode)
-        {
-            Settings.Mode = mode;
-            return Settings;
-        }
-
-        public void SetSettings(XmlNode settings)
-        {
-            Settings.SetSettings(settings);
-        }
-
-        public TimeSpan CalculateTotalPlaytime(LiveSplitState state)
-        {
-            var totalPlaytime = TimeSpan.Zero;
-
-            foreach (var attempt in state.Run.AttemptHistory)
-            {
-                var duration = attempt.Duration;
-
-                if (duration.HasValue)
-                {
-                    //Either >= 1.6.0 or a finished run
-                    totalPlaytime += duration.Value - (attempt.PauseTime ?? TimeSpan.Zero);
-                }
-                else
-                {
-                    //Must be < 1.6.0 and a reset
-                    //Calculate the sum of the segments for that run
-                    
-                    foreach (var segment in state.Run)
-                    {
-                        Time segmentHistoryElement;
-                        if (segment.SegmentHistory.TryGetValue(attempt.Index, out segmentHistoryElement) && segmentHistoryElement.RealTime.HasValue)
-                            totalPlaytime += segmentHistoryElement.RealTime.Value;
-                    }
-                }
-            }
-
-            totalPlaytime += state.CurrentAttemptDuration - (state.PauseTime ?? TimeSpan.Zero);
-
-            return totalPlaytime;
-        }
-
-        public void Update(IInvalidator invalidator, LiveSplitState state, float width, float height, LayoutMode mode)
-        {
-            InternalComponent.Formatter = Settings.ShowTotalHours ? HoursTimeFormatter : DaysTimeFormatter;
-
-            if (LastAttemptCount != state.Run.AttemptHistory.Count 
-                || LastPhase != state.CurrentPhase
-                || LastRun != state.Run
-                || state.CurrentPhase == TimerPhase.Running 
-                || state.CurrentPhase == TimerPhase.Paused)
-            {
-                InternalComponent.TimeValue = CalculateTotalPlaytime(state);
-
-                LastAttemptCount = state.Run.AttemptHistory.Count;
-                LastPhase = state.CurrentPhase;
-                LastRun = state.Run;
-            }
-
-            InternalComponent.Update(invalidator, state, width, height, mode);
-        }
-
-        public void Dispose()
-        {
-            InternalComponent.Dispose();
-        }
-
-        public int GetSettingsHashCode() => Settings.GetSettingsHashCode();
+            CurrentState = state
+        };
     }
+
+    private void DrawBackground(Graphics g, LiveSplitState state, float width, float height)
+    {
+        if (Settings.BackgroundColor.A > 0
+            || Settings.BackgroundGradient != GradientType.Plain
+            && Settings.BackgroundColor2.A > 0)
+        {
+            var gradientBrush = new LinearGradientBrush(
+                        new PointF(0, 0),
+                        Settings.BackgroundGradient == GradientType.Horizontal
+                        ? new PointF(width, 0)
+                        : new PointF(0, height),
+                        Settings.BackgroundColor,
+                        Settings.BackgroundGradient == GradientType.Plain
+                        ? Settings.BackgroundColor
+                        : Settings.BackgroundColor2);
+            g.FillRectangle(gradientBrush, 0, 0, width, height);
+        }
+    }
+
+    public void DrawHorizontal(Graphics g, LiveSplitState state, float height, Region clipRegion)
+    {
+        DrawBackground(g, state, HorizontalWidth, height);
+
+        InternalComponent.NameLabel.HasShadow
+            = InternalComponent.ValueLabel.HasShadow
+            = state.LayoutSettings.DropShadows;
+
+        InternalComponent.NameLabel.ForeColor = Settings.OverrideTextColor ? Settings.TextColor : state.LayoutSettings.TextColor;
+        InternalComponent.ValueLabel.ForeColor = Settings.OverrideTimeColor ? Settings.TimeColor : state.LayoutSettings.TextColor;
+
+        InternalComponent.DrawHorizontal(g, state, height, clipRegion);
+    }
+
+    public void DrawVertical(Graphics g, LiveSplitState state, float width, Region clipRegion)
+    {
+        DrawBackground(g, state, width, VerticalHeight);
+
+        InternalComponent.DisplayTwoRows = Settings.Display2Rows;
+
+        InternalComponent.NameLabel.HasShadow
+            = InternalComponent.ValueLabel.HasShadow
+            = state.LayoutSettings.DropShadows;
+
+        InternalComponent.NameLabel.ForeColor = Settings.OverrideTextColor ? Settings.TextColor : state.LayoutSettings.TextColor;
+        InternalComponent.ValueLabel.ForeColor = Settings.OverrideTimeColor ? Settings.TimeColor : state.LayoutSettings.TextColor;
+
+        InternalComponent.DrawVertical(g, state, width, clipRegion);
+    }
+
+    public XmlNode GetSettings(XmlDocument document)
+    {
+        return Settings.GetSettings(document);
+    }
+
+    public Control GetSettingsControl(LayoutMode mode)
+    {
+        Settings.Mode = mode;
+        return Settings;
+    }
+
+    public void SetSettings(XmlNode settings)
+    {
+        Settings.SetSettings(settings);
+    }
+
+    public TimeSpan CalculateTotalPlaytime(LiveSplitState state)
+    {
+        var totalPlaytime = TimeSpan.Zero;
+
+        foreach (var attempt in state.Run.AttemptHistory)
+        {
+            var duration = attempt.Duration;
+
+            if (duration.HasValue)
+            {
+                //Either >= 1.6.0 or a finished run
+                totalPlaytime += duration.Value - (attempt.PauseTime ?? TimeSpan.Zero);
+            }
+            else
+            {
+                //Must be < 1.6.0 and a reset
+                //Calculate the sum of the segments for that run
+
+                foreach (var segment in state.Run)
+                {
+                    Time segmentHistoryElement;
+                    if (segment.SegmentHistory.TryGetValue(attempt.Index, out segmentHistoryElement) && segmentHistoryElement.RealTime.HasValue)
+                        totalPlaytime += segmentHistoryElement.RealTime.Value;
+                }
+            }
+        }
+
+        totalPlaytime += state.CurrentAttemptDuration - (state.PauseTime ?? TimeSpan.Zero);
+
+        return totalPlaytime;
+    }
+
+    public void Update(IInvalidator invalidator, LiveSplitState state, float width, float height, LayoutMode mode)
+    {
+        InternalComponent.Formatter = Settings.ShowTotalHours ? HoursTimeFormatter : DaysTimeFormatter;
+
+        if (LastAttemptCount != state.Run.AttemptHistory.Count
+            || LastPhase != state.CurrentPhase
+            || LastRun != state.Run
+            || state.CurrentPhase == TimerPhase.Running
+            || state.CurrentPhase == TimerPhase.Paused)
+        {
+            InternalComponent.TimeValue = CalculateTotalPlaytime(state);
+
+            LastAttemptCount = state.Run.AttemptHistory.Count;
+            LastPhase = state.CurrentPhase;
+            LastRun = state.Run;
+        }
+
+        InternalComponent.Update(invalidator, state, width, height, mode);
+    }
+
+    public void Dispose()
+    {
+        InternalComponent.Dispose();
+    }
+
+    public int GetSettingsHashCode() => Settings.GetSettingsHashCode();
 }

--- a/src/LiveSplit.TotalPlaytime/UI/Components/TotalPlaytimeFactory.cs
+++ b/src/LiveSplit.TotalPlaytime/UI/Components/TotalPlaytimeFactory.cs
@@ -13,7 +13,10 @@ public class TotalPlaytimeFactory : IComponentFactory
 
     public string ComponentName => "Total Playtime";
 
-    public IComponent Create(LiveSplitState state) => new TotalPlaytimeComponent(state);
+    public IComponent Create(LiveSplitState state)
+    {
+        return new TotalPlaytimeComponent(state);
+    }
 
     public string Description => "Shows the total playtime for running with these splits.";
 

--- a/src/LiveSplit.TotalPlaytime/UI/Components/TotalPlaytimeFactory.cs
+++ b/src/LiveSplit.TotalPlaytime/UI/Components/TotalPlaytimeFactory.cs
@@ -1,27 +1,27 @@
-﻿using LiveSplit.Model;
+﻿using System;
+
+using LiveSplit.Model;
 using LiveSplit.UI.Components;
-using System;
 
 [assembly: ComponentFactory(typeof(TotalPlaytimeFactory))]
 
-namespace LiveSplit.UI.Components
+namespace LiveSplit.UI.Components;
+
+public class TotalPlaytimeFactory : IComponentFactory
 {
-    public class TotalPlaytimeFactory : IComponentFactory
-    {
-        public ComponentCategory Category => ComponentCategory.Information;
+    public ComponentCategory Category => ComponentCategory.Information;
 
-        public string ComponentName => "Total Playtime";
+    public string ComponentName => "Total Playtime";
 
-        public IComponent Create(LiveSplitState state) => new TotalPlaytimeComponent(state);
+    public IComponent Create(LiveSplitState state) => new TotalPlaytimeComponent(state);
 
-        public string Description => "Shows the total playtime for running with these splits.";
+    public string Description => "Shows the total playtime for running with these splits.";
 
-        public string XMLURL => "http://livesplit.org/update/Components/update.LiveSplit.TotalPlaytime.xml";
+    public string XMLURL => "http://livesplit.org/update/Components/update.LiveSplit.TotalPlaytime.xml";
 
-        public string UpdateURL => "http://livesplit.org/update/";
+    public string UpdateURL => "http://livesplit.org/update/";
 
-        public Version Version => Version.Parse("1.8.29");
+    public Version Version => Version.Parse("1.8.29");
 
-        public string UpdateName => ComponentName;
-    }
+    public string UpdateName => ComponentName;
 }

--- a/src/LiveSplit.TotalPlaytime/UI/Components/TotalPlaytimeSettings.cs
+++ b/src/LiveSplit.TotalPlaytime/UI/Components/TotalPlaytimeSettings.cs
@@ -53,17 +53,17 @@ public partial class TotalPlaytimeSettings : UserControl
         chkShowTotalHours.DataBindings.Add("Checked", this, "ShowTotalHours", false, DataSourceUpdateMode.OnPropertyChanged);
     }
 
-    void chkOverrideTimeColor_CheckedChanged(object sender, EventArgs e)
+    private void chkOverrideTimeColor_CheckedChanged(object sender, EventArgs e)
     {
         label2.Enabled = btnTimeColor.Enabled = chkOverrideTimeColor.Checked;
     }
 
-    void chkOverrideTextColor_CheckedChanged(object sender, EventArgs e)
+    private void chkOverrideTextColor_CheckedChanged(object sender, EventArgs e)
     {
         label1.Enabled = btnTextColor.Enabled = chkOverrideTextColor.Checked;
     }
 
-    void TotalPlaytimeSettings_Load(object sender, EventArgs e)
+    private void TotalPlaytimeSettings_Load(object sender, EventArgs e)
     {
         chkOverrideTextColor_CheckedChanged(null, null);
         chkOverrideTimeColor_CheckedChanged(null, null);
@@ -81,7 +81,7 @@ public partial class TotalPlaytimeSettings : UserControl
         }
     }
 
-    void cmbGradientType_SelectedIndexChanged(object sender, EventArgs e)
+    private void cmbGradientType_SelectedIndexChanged(object sender, EventArgs e)
     {
         btnColor1.Visible = cmbGradientType.SelectedItem.ToString() != "Plain";
         btnColor2.DataBindings.Clear();

--- a/src/LiveSplit.TotalPlaytime/UI/Components/TotalPlaytimeSettings.cs
+++ b/src/LiveSplit.TotalPlaytime/UI/Components/TotalPlaytimeSettings.cs
@@ -19,8 +19,8 @@ public partial class TotalPlaytimeSettings : UserControl
     public GradientType BackgroundGradient { get; set; }
     public string GradientString
     {
-        get { return BackgroundGradient.ToString(); }
-        set { BackgroundGradient = (GradientType)Enum.Parse(typeof(GradientType), value); }
+        get => BackgroundGradient.ToString();
+        set => BackgroundGradient = (GradientType)Enum.Parse(typeof(GradientType), value);
     }
 
     public LiveSplitState CurrentState { get; set; }

--- a/src/LiveSplit.TotalPlaytime/UI/Components/TotalPlaytimeSettings.cs
+++ b/src/LiveSplit.TotalPlaytime/UI/Components/TotalPlaytimeSettings.cs
@@ -105,7 +105,7 @@ public partial class TotalPlaytimeSettings : UserControl
 
     public XmlNode GetSettings(XmlDocument document)
     {
-        var parent = document.CreateElement("Settings");
+        XmlElement parent = document.CreateElement("Settings");
         CreateSettingsNode(document, parent);
         return parent;
     }

--- a/src/LiveSplit.TotalPlaytime/UI/Components/TotalPlaytimeSettings.cs
+++ b/src/LiveSplit.TotalPlaytime/UI/Components/TotalPlaytimeSettings.cs
@@ -1,136 +1,136 @@
-﻿using LiveSplit.Model;
-using System;
+﻿using System;
 using System.Drawing;
 using System.Windows.Forms;
 using System.Xml;
 
-namespace LiveSplit.UI.Components
+using LiveSplit.Model;
+
+namespace LiveSplit.UI.Components;
+
+public partial class TotalPlaytimeSettings : UserControl
 {
-    public partial class TotalPlaytimeSettings : UserControl
+    public Color TextColor { get; set; }
+    public bool OverrideTextColor { get; set; }
+    public Color TimeColor { get; set; }
+    public bool OverrideTimeColor { get; set; }
+
+    public Color BackgroundColor { get; set; }
+    public Color BackgroundColor2 { get; set; }
+    public GradientType BackgroundGradient { get; set; }
+    public string GradientString
     {
-        public Color TextColor { get; set; }
-        public bool OverrideTextColor { get; set; }
-        public Color TimeColor { get; set; }
-        public bool OverrideTimeColor { get; set; }
+        get { return BackgroundGradient.ToString(); }
+        set { BackgroundGradient = (GradientType)Enum.Parse(typeof(GradientType), value); }
+    }
 
-        public Color BackgroundColor { get; set; }
-        public Color BackgroundColor2 { get; set; }
-        public GradientType BackgroundGradient { get; set; }
-        public string GradientString
+    public LiveSplitState CurrentState { get; set; }
+    public bool Display2Rows { get; set; }
+    public bool ShowTotalHours { get; set; }
+
+    public LayoutMode Mode { get; set; }
+
+    public TotalPlaytimeSettings()
+    {
+        InitializeComponent();
+
+        TextColor = Color.FromArgb(255, 255, 255);
+        OverrideTextColor = false;
+        TimeColor = Color.FromArgb(255, 255, 255);
+        OverrideTimeColor = false;
+        BackgroundColor = Color.Transparent;
+        BackgroundColor2 = Color.Transparent;
+        BackgroundGradient = GradientType.Plain;
+        Display2Rows = false;
+        ShowTotalHours = false;
+
+        chkOverrideTextColor.DataBindings.Add("Checked", this, "OverrideTextColor", false, DataSourceUpdateMode.OnPropertyChanged);
+        btnTextColor.DataBindings.Add("BackColor", this, "TextColor", false, DataSourceUpdateMode.OnPropertyChanged);
+        chkOverrideTimeColor.DataBindings.Add("Checked", this, "OverrideTimeColor", false, DataSourceUpdateMode.OnPropertyChanged);
+        btnTimeColor.DataBindings.Add("BackColor", this, "TimeColor", false, DataSourceUpdateMode.OnPropertyChanged);
+        cmbGradientType.DataBindings.Add("SelectedItem", this, "GradientString", false, DataSourceUpdateMode.OnPropertyChanged);
+        btnColor1.DataBindings.Add("BackColor", this, "BackgroundColor", false, DataSourceUpdateMode.OnPropertyChanged);
+        btnColor2.DataBindings.Add("BackColor", this, "BackgroundColor2", false, DataSourceUpdateMode.OnPropertyChanged);
+        chkShowTotalHours.DataBindings.Add("Checked", this, "ShowTotalHours", false, DataSourceUpdateMode.OnPropertyChanged);
+    }
+
+    void chkOverrideTimeColor_CheckedChanged(object sender, EventArgs e)
+    {
+        label2.Enabled = btnTimeColor.Enabled = chkOverrideTimeColor.Checked;
+    }
+
+    void chkOverrideTextColor_CheckedChanged(object sender, EventArgs e)
+    {
+        label1.Enabled = btnTextColor.Enabled = chkOverrideTextColor.Checked;
+    }
+
+    void TotalPlaytimeSettings_Load(object sender, EventArgs e)
+    {
+        chkOverrideTextColor_CheckedChanged(null, null);
+        chkOverrideTimeColor_CheckedChanged(null, null);
+        if (Mode == LayoutMode.Horizontal)
         {
-            get { return BackgroundGradient.ToString(); }
-            set { BackgroundGradient = (GradientType)Enum.Parse(typeof(GradientType), value); }
+            chkTwoRows.Enabled = false;
+            chkTwoRows.DataBindings.Clear();
+            chkTwoRows.Checked = true;
         }
-
-        public LiveSplitState CurrentState { get; set; }
-        public bool Display2Rows { get; set; }
-        public bool ShowTotalHours { get; set; }
-
-        public LayoutMode Mode { get; set; }
-
-        public TotalPlaytimeSettings()
+        else
         {
-            InitializeComponent();
-
-            TextColor = Color.FromArgb(255, 255, 255);
-            OverrideTextColor = false;
-            TimeColor = Color.FromArgb(255, 255, 255);
-            OverrideTimeColor = false;
-            BackgroundColor = Color.Transparent;
-            BackgroundColor2 = Color.Transparent;
-            BackgroundGradient = GradientType.Plain;
-            Display2Rows = false;
-            ShowTotalHours = false;
-
-            chkOverrideTextColor.DataBindings.Add("Checked", this, "OverrideTextColor", false, DataSourceUpdateMode.OnPropertyChanged);
-            btnTextColor.DataBindings.Add("BackColor", this, "TextColor", false, DataSourceUpdateMode.OnPropertyChanged);
-            chkOverrideTimeColor.DataBindings.Add("Checked", this, "OverrideTimeColor", false, DataSourceUpdateMode.OnPropertyChanged);
-            btnTimeColor.DataBindings.Add("BackColor", this, "TimeColor", false, DataSourceUpdateMode.OnPropertyChanged);
-            cmbGradientType.DataBindings.Add("SelectedItem", this, "GradientString", false, DataSourceUpdateMode.OnPropertyChanged);
-            btnColor1.DataBindings.Add("BackColor", this, "BackgroundColor", false, DataSourceUpdateMode.OnPropertyChanged);
-            btnColor2.DataBindings.Add("BackColor", this, "BackgroundColor2", false, DataSourceUpdateMode.OnPropertyChanged);
-            chkShowTotalHours.DataBindings.Add("Checked", this, "ShowTotalHours", false, DataSourceUpdateMode.OnPropertyChanged);
+            chkTwoRows.Enabled = true;
+            chkTwoRows.DataBindings.Clear();
+            chkTwoRows.DataBindings.Add("Checked", this, "Display2Rows", false, DataSourceUpdateMode.OnPropertyChanged);
         }
+    }
 
-        void chkOverrideTimeColor_CheckedChanged(object sender, EventArgs e)
-        {
-            label2.Enabled = btnTimeColor.Enabled = chkOverrideTimeColor.Checked;
-        }
+    void cmbGradientType_SelectedIndexChanged(object sender, EventArgs e)
+    {
+        btnColor1.Visible = cmbGradientType.SelectedItem.ToString() != "Plain";
+        btnColor2.DataBindings.Clear();
+        btnColor2.DataBindings.Add("BackColor", this, btnColor1.Visible ? "BackgroundColor2" : "BackgroundColor", false, DataSourceUpdateMode.OnPropertyChanged);
+        GradientString = cmbGradientType.SelectedItem.ToString();
+    }
 
-        void chkOverrideTextColor_CheckedChanged(object sender, EventArgs e)
-        {
-            label1.Enabled = btnTextColor.Enabled = chkOverrideTextColor.Checked;
-        }
+    public void SetSettings(XmlNode node)
+    {
+        var element = (XmlElement)node;
+        TextColor = SettingsHelper.ParseColor(element["TextColor"]);
+        OverrideTextColor = SettingsHelper.ParseBool(element["OverrideTextColor"]);
+        TimeColor = SettingsHelper.ParseColor(element["TimeColor"]);
+        OverrideTimeColor = SettingsHelper.ParseBool(element["OverrideTimeColor"]);
+        BackgroundColor = SettingsHelper.ParseColor(element["BackgroundColor"]);
+        BackgroundColor2 = SettingsHelper.ParseColor(element["BackgroundColor2"]);
+        GradientString = SettingsHelper.ParseString(element["BackgroundGradient"]);
+        Display2Rows = SettingsHelper.ParseBool(element["Display2Rows"]);
+        ShowTotalHours = SettingsHelper.ParseBool(element["ShowTotalHours"], false);
+    }
 
-        void TotalPlaytimeSettings_Load(object sender, EventArgs e)
-        {
-            chkOverrideTextColor_CheckedChanged(null, null);
-            chkOverrideTimeColor_CheckedChanged(null, null);
-            if (Mode == LayoutMode.Horizontal)
-            {
-                chkTwoRows.Enabled = false;
-                chkTwoRows.DataBindings.Clear();
-                chkTwoRows.Checked = true;
-            }
-            else
-            {
-                chkTwoRows.Enabled = true;
-                chkTwoRows.DataBindings.Clear();
-                chkTwoRows.DataBindings.Add("Checked", this, "Display2Rows", false, DataSourceUpdateMode.OnPropertyChanged);
-            }
-        }
+    public XmlNode GetSettings(XmlDocument document)
+    {
+        var parent = document.CreateElement("Settings");
+        CreateSettingsNode(document, parent);
+        return parent;
+    }
 
-        void cmbGradientType_SelectedIndexChanged(object sender, EventArgs e)
-        {
-            btnColor1.Visible = cmbGradientType.SelectedItem.ToString() != "Plain";
-            btnColor2.DataBindings.Clear();
-            btnColor2.DataBindings.Add("BackColor", this, btnColor1.Visible ? "BackgroundColor2" : "BackgroundColor", false, DataSourceUpdateMode.OnPropertyChanged);
-            GradientString = cmbGradientType.SelectedItem.ToString();
-        }
+    public int GetSettingsHashCode()
+    {
+        return CreateSettingsNode(null, null);
+    }
 
-        public void SetSettings(XmlNode node)
-        {
-            var element = (XmlElement)node;
-            TextColor = SettingsHelper.ParseColor(element["TextColor"]);
-            OverrideTextColor = SettingsHelper.ParseBool(element["OverrideTextColor"]);
-            TimeColor = SettingsHelper.ParseColor(element["TimeColor"]);
-            OverrideTimeColor = SettingsHelper.ParseBool(element["OverrideTimeColor"]);
-            BackgroundColor = SettingsHelper.ParseColor(element["BackgroundColor"]);
-            BackgroundColor2 = SettingsHelper.ParseColor(element["BackgroundColor2"]);
-            GradientString = SettingsHelper.ParseString(element["BackgroundGradient"]);
-            Display2Rows = SettingsHelper.ParseBool(element["Display2Rows"]);
-            ShowTotalHours = SettingsHelper.ParseBool(element["ShowTotalHours"], false);
-        }
+    private int CreateSettingsNode(XmlDocument document, XmlElement parent)
+    {
+        return SettingsHelper.CreateSetting(document, parent, "Version", "1.6") ^
+        SettingsHelper.CreateSetting(document, parent, "TextColor", TextColor) ^
+        SettingsHelper.CreateSetting(document, parent, "OverrideTextColor", OverrideTextColor) ^
+        SettingsHelper.CreateSetting(document, parent, "TimeColor", TimeColor) ^
+        SettingsHelper.CreateSetting(document, parent, "OverrideTimeColor", OverrideTimeColor) ^
+        SettingsHelper.CreateSetting(document, parent, "BackgroundColor", BackgroundColor) ^
+        SettingsHelper.CreateSetting(document, parent, "BackgroundColor2", BackgroundColor2) ^
+        SettingsHelper.CreateSetting(document, parent, "BackgroundGradient", BackgroundGradient) ^
+        SettingsHelper.CreateSetting(document, parent, "Display2Rows", Display2Rows) ^
+        SettingsHelper.CreateSetting(document, parent, "ShowTotalHours", ShowTotalHours);
+    }
 
-        public XmlNode GetSettings(XmlDocument document)
-        {
-            var parent = document.CreateElement("Settings");
-            CreateSettingsNode(document, parent);
-            return parent;
-        }
-
-        public int GetSettingsHashCode()
-        {
-            return CreateSettingsNode(null, null);
-        }
-
-        private int CreateSettingsNode(XmlDocument document, XmlElement parent)
-        {
-            return SettingsHelper.CreateSetting(document, parent, "Version", "1.6") ^
-            SettingsHelper.CreateSetting(document, parent, "TextColor", TextColor) ^
-            SettingsHelper.CreateSetting(document, parent, "OverrideTextColor", OverrideTextColor) ^
-            SettingsHelper.CreateSetting(document, parent, "TimeColor", TimeColor) ^
-            SettingsHelper.CreateSetting(document, parent, "OverrideTimeColor", OverrideTimeColor) ^
-            SettingsHelper.CreateSetting(document, parent, "BackgroundColor", BackgroundColor) ^
-            SettingsHelper.CreateSetting(document, parent, "BackgroundColor2", BackgroundColor2) ^
-            SettingsHelper.CreateSetting(document, parent, "BackgroundGradient", BackgroundGradient) ^
-            SettingsHelper.CreateSetting(document, parent, "Display2Rows", Display2Rows) ^
-            SettingsHelper.CreateSetting(document, parent, "ShowTotalHours", ShowTotalHours);
-        }
-
-        private void ColorButtonClick(object sender, EventArgs e)
-        {
-            SettingsHelper.ColorButtonClick((Button)sender, this);
-        }
+    private void ColorButtonClick(object sender, EventArgs e)
+    {
+        SettingsHelper.ColorButtonClick((Button)sender, this);
     }
 }


### PR DESCRIPTION
Parent PR: https://github.com/LiveSplit/LiveSplit/pull/2533

### Description

* Introduces an `.editorconfig` file to enforce consistent style rules.
* Upgrades the language version to C# 12 (most recent stable).
* Adds `PolySharp` to allow for support of some language features which require runtime support (`Index` & `Range` operators).
* Fixes some warnings.
